### PR TITLE
Use prototype link from GOV.UK Pay

### DIFF
--- a/app/views/check-your-answers.html
+++ b/app/views/check-your-answers.html
@@ -84,7 +84,7 @@
       <p class="govuk-body govuk-!-margin-bottom-7">By submitting an application you confirm that as far as you know, the information you’ve provided is correct and complete.</p>
 
       {{ govukButton({
-        href: "https://www.gov.uk/payments/chris-woz-here/test",
+        href: "https://products.payments.service.gov.uk/pay/0e1499a7601443a29d1c285f22312da7",
         text: "Accept and proceed to payment"
       }) }}
 


### PR DESCRIPTION
Unlike the previous payment link this:
- takes the user straight to the payment page
- has the correct service name, description and amount

***

![image](https://user-images.githubusercontent.com/355079/73372516-44405c00-42af-11ea-80a7-20c8552e92c5.png)
