### PR TITLE
Only require authentication on admin pages.

### DIFF
--- a/lib/middleware/authentication/authentication.js
+++ b/lib/middleware/authentication/authentication.js
@@ -25,6 +25,8 @@ module.exports = function (req, res, next) {
   const username = process.env.USERNAME
   const password = process.env.PASSWORD
 
+  const isAdminPage = req.path.startsWith('/backstage') || req.path === '/'
+
   if (env === 'production' && useAuth === 'true') {
     if (!username || !password) {
       console.error('Username or password is not set.')
@@ -33,7 +35,9 @@ module.exports = function (req, res, next) {
 
     const user = basicAuth(req)
 
-    if (!user || user.name !== username || user.pass !== password) {
+    const usenameAndPasswordIsIncorrect = !user || user.name !== username || user.pass !== password
+
+    if (isAdminPage && usenameAndPasswordIsIncorrect) {
       res.set('WWW-Authenticate', 'Basic realm=Authorization Required')
       return res.sendStatus(401)
     }


### PR DESCRIPTION
We are sending tasks via email to people's personal devices so we dont want them to have to use the authentication modal.

We've chosen to lower risk by keeping authentication on the administration pages.