### PR TITLE
Remove temporary badge link from confirmation page

### DIFF
--- a/app/views/confirmation.html
+++ b/app/views/confirmation.html
@@ -23,12 +23,9 @@
       </p>
 
       <p class="govuk-body">
-        In the meantime, you can <a href="#[link]">download a temporary Blue Badge</a> to print and display in your vehicle.
+        In the meantime, we’ve sent an email with a link to your temporary Blue Badge to details to {{ data['contact-by-email-address'] or 'your email address' }}. Print and display this until your Blue Badge arrives.
       </p>
 
-      <p class="govuk-body">
-        We’ve sent an email with these details to [email address].
-      </p>
     </div>
   </div>
 


### PR DESCRIPTION
We want them to download it from their email account instead, so we can test the Document Download feature of Notify,

Content from https://docs.google.com/document/d/1YESG2j9wnjcZTjhYmlJBK_ZRaXIEi5EG2FsrOBBBahs/edit?ts=5e29ca26