### PR TITLE
Add H2 to confirmation pages

### DIFF
--- a/app/views/confirmation.html
+++ b/app/views/confirmation.html
@@ -18,6 +18,10 @@
         Thank you for applying for a Blue Badge.
       </p>
 
+      <h2 class="govuk-heading-m">
+        What happens next
+      </h2>
+
       <p class="govuk-body">
         We will check your application, then send your Blue Badge within 10 working days.
       </p>


### PR DESCRIPTION
This matches the suggested content in the Design System documentation:
https://design-system.service.gov.uk/patterns/confirmation-pages/

# Before 

![image](https://user-images.githubusercontent.com/355079/73769494-a9de8d80-4772-11ea-8664-89c7bda05f51.png)

# After 

![image](https://user-images.githubusercontent.com/355079/73769473-a1865280-4772-11ea-8e2d-473f535893d8.png)
