### PR TITLE
Add a cookie banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,4 +7,6 @@ if (window.console && window.console.info) {
 
 $(document).ready(function () {
   window.GOVUKFrontend.initAll()
+
+  window.GOVUK.modules.start()
 })

--- a/app/assets/javascripts/cookie-banner.js
+++ b/app/assets/javascripts/cookie-banner.js
@@ -1,0 +1,95 @@
+// https://github.com/alphagov/govuk_publishing_components/blob/19f17b858c939ec82a3de910751db8e482e65dcd/app/assets/javascripts/govuk_publishing_components/components/cookie-banner.js
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function CookieBanner () { }
+
+  CookieBanner.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$module.hideCookieMessage = this.hideCookieMessage.bind(this)
+    this.$module.showConfirmationMessage = this.showConfirmationMessage.bind(this)
+    this.$module.setCookieConsent = this.setCookieConsent.bind(this)
+
+    this.$module.cookieBanner = document.querySelector('.gem-c-cookie-banner')
+    this.$module.cookieBannerConfirmationMessage = this.$module.querySelector('.gem-c-cookie-banner__confirmation')
+
+    this.setupCookieMessage()
+  }
+
+  CookieBanner.prototype.setupCookieMessage = function () {
+    this.$hideLinks = this.$module.querySelectorAll('button[data-hide-cookie-banner]')
+    if (this.$hideLinks && this.$hideLinks.length) {
+      for (var i = 0; i < this.$hideLinks.length; i++) {
+        this.$hideLinks[i].addEventListener('click', this.$module.hideCookieMessage)
+      }
+    }
+
+    this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies]')
+    if (this.$acceptCookiesLink) {
+      this.$acceptCookiesLink.addEventListener('click', this.$module.setCookieConsent)
+    }
+
+    this.showCookieMessage()
+  }
+
+  CookieBanner.prototype.showCookieMessage = function () {
+    // Show the cookie banner if not in the cookie settings page or in an iframe
+    if (!this.isInCookiesPage() && !this.isInIframe()) {
+      var shouldHaveCookieMessage = (this.$module && window.GOVUK.cookie('cookies_preferences_set') !== 'true')
+
+      if (shouldHaveCookieMessage) {
+        this.$module.style.display = 'block'
+      } else {
+        this.$module.style.display = 'none'
+      }
+    } else {
+      this.$module.style.display = 'none'
+    }
+  }
+
+  CookieBanner.prototype.hideCookieMessage = function (event) {
+    if (this.$module) {
+      this.$module.style.display = 'none'
+      window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+    }
+
+    if (event.target) {
+      event.preventDefault()
+    }
+  }
+
+  CookieBanner.prototype.setCookieConsent = function () {
+    this.$module.showConfirmationMessage()
+    this.$module.cookieBannerConfirmationMessage.focus()
+    window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })
+    if (window.GOVUK.analyticsInit) {
+      window.GOVUK.analyticsInit()
+    }
+    if (window.GOVUK.globalBarInit) {
+      window.GOVUK.globalBarInit.init()
+    }
+  }
+
+  CookieBanner.prototype.showConfirmationMessage = function () {
+    this.$cookieBannerMainContent = document.querySelector('.gem-c-cookie-banner__wrapper')
+
+    this.$cookieBannerMainContent.style.display = 'none'
+    this.$module.cookieBannerConfirmationMessage.style.display = 'block'
+  }
+
+  CookieBanner.prototype.listenForCrossOriginMessages = function () {
+    window.addEventListener('message', this.receiveMessage.bind(this), false)
+  }
+
+  CookieBanner.prototype.isInCookiesPage = function () {
+    return window.location.pathname === '/help/cookies'
+  }
+
+  CookieBanner.prototype.isInIframe = function () {
+    return window.parent && window.location !== window.parent.location
+  }
+
+  Modules.CookieBanner = CookieBanner
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/cookie.js
+++ b/app/assets/javascripts/cookie.js
@@ -1,0 +1,37 @@
+// Extracted from
+// https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/lib/cookie-functions.js
+
+window.GOVUK.cookie = function (name, value, options) {
+  if (typeof value !== 'undefined') {
+    if (typeof options === 'undefined') {
+      options = {}
+    }
+    var cookieString = name + '=' + value + '; path=/'
+    if (options.days) {
+      var date = new Date()
+      date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000))
+      cookieString = cookieString + '; expires=' + date.toGMTString()
+    }
+    if (document.location.protocol === 'https:') {
+      cookieString = cookieString + '; Secure'
+    }
+    document.cookie = cookieString
+  } else {
+    return window.GOVUK.getCookie(name)
+  }
+};
+
+window.GOVUK.getCookie = function (name) {
+  var nameEQ = name + '='
+  var cookies = document.cookie.split(';')
+  for (var i = 0, len = cookies.length; i < len; i++) {
+    var cookie = cookies[i]
+    while (cookie.charAt(0) === ' ') {
+      cookie = cookie.substring(1, cookie.length)
+    }
+    if (cookie.indexOf(nameEQ) === 0) {
+      return decodeURIComponent(cookie.substring(nameEQ.length))
+    }
+  }
+  return null
+}

--- a/app/assets/javascripts/modules.js
+++ b/app/assets/javascripts/modules.js
@@ -1,0 +1,63 @@
+// https://github.com/alphagov/govuk_publishing_components/blob/19f17b858c939ec82a3de910751db8e482e65dcd/app/assets/javascripts/govuk_publishing_components/modules.js
+
+;(function (global) {
+  'use strict'
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+  GOVUK.Modules = GOVUK.Modules || {}
+
+  GOVUK.modules = {
+    find: function (container) {
+      container = container || $('body')
+
+      var modules
+      var moduleSelector = '[data-module]'
+
+      modules = container.find(moduleSelector)
+
+      // Container could be a module too
+      if (container.is(moduleSelector)) {
+        modules = modules.add(container)
+      }
+
+      return modules
+    },
+
+    start: function (container) {
+      var modules = this.find(container)
+
+      for (var i = 0, l = modules.length; i < l; i++) {
+        var module
+        var element = $(modules[i])
+        var type = camelCaseAndCapitalise(element.data('module'))
+        var started = element.data('module-started')
+
+        if (typeof GOVUK.Modules[type] === 'function' && !started) {
+          module = new GOVUK.Modules[type]()
+          module.start(element)
+          element.data('module-started', true)
+        }
+      }
+
+      // eg selectable-table to SelectableTable
+      function camelCaseAndCapitalise (string) {
+        return capitaliseFirstLetter(camelCase(string))
+      }
+
+      // http://stackoverflow.com/questions/6660977/convert-hyphens-to-camel-case-camelcase
+      function camelCase (string) {
+        return string.replace(/-([a-z])/g, function (g) {
+          return g.charAt(1).toUpperCase()
+        })
+      }
+
+      // http://stackoverflow.com/questions/1026069/capitalize-the-first-letter-of-string-in-javascript
+      function capitaliseFirstLetter (string) {
+        return string.charAt(0).toUpperCase() + string.slice(1)
+      }
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/sass/components/_cookie-banner.scss
+++ b/app/assets/sass/components/_cookie-banner.scss
@@ -1,24 +1,157 @@
-.app-cookie-banner {
-  @include govuk-font(16);
-  @include govuk-text-colour;
+// https://github.com/alphagov/govuk_publishing_components/blob/19f17b858c939ec82a3de910751db8e482e65dcd/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
 
-  box-sizing: border-box;
-  width: 100%;
+$govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
 
-  padding-top: govuk-spacing(3);
-  padding-right: govuk-spacing(3);
-  padding-bottom: govuk-spacing(3);
-  padding-left: govuk-spacing(3);
-  background-color: lighten(desaturate(govuk-colour("light-blue"), 8.46), 42.55);
-}
-
-.app-cookie-banner__message {
-  margin: 0;
-  @include govuk-width-container;
-}
-
-@include govuk-media-query($media-type: print) {
-  .app-cookie-banner {
-    display: none !important;
+.js-enabled {
+  .gem-c-cookie-banner {
+    display: none; // shown with JS, always on for non-JS
   }
 }
+
+.gem-c-cookie-banner {
+  @include govuk-font($size: 16);
+  padding: govuk-spacing(2) 0;
+  background-color: $govuk-cookie-banner-background;
+}
+
+.gem-c-cookie-banner__message {
+  display: inline-block;
+  padding-bottom: govuk-spacing(2);
+
+  @include govuk-font($size: 16);
+  @include govuk-media-query($from: desktop) {
+    padding-right: govuk-spacing(4);
+  }
+}
+
+.gem-c-cookie-banner__button {
+
+  &.govuk-grid-column-one-half-from-desktop {
+    padding: 0;
+  }
+
+  .govuk-button {
+    @include govuk-media-query($from: desktop) {
+      width: 90%;
+    }
+
+    @include govuk-media-query($until: desktop) {
+      margin-bottom: govuk-spacing(4);
+    }
+
+  }
+}
+
+// Only show accept button if users have js and can accept
+.gem-c-cookie-banner__button-accept {
+  display: none;
+}
+
+.js-enabled .gem-c-cookie-banner__button-accept {
+  display: inline-block;
+}
+
+
+.gem-c-cookie-banner__confirmation {
+  display: none;
+  position: relative;
+  padding: govuk-spacing(1);
+
+
+  // This element is focused using JavaScript so that it's being read out by screen readers
+  // for this reason we don't want to show the default outline or emphasise it visually using `govuk-focused-text`
+  &:focus {
+    outline: none;
+  }
+}
+
+.gem-c-cookie-banner__confirmation-message,
+.gem-c-cookie-banner__hide-button {
+  display: block;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+  }
+}
+
+.gem-c-cookie-banner__confirmation-message {
+  margin-right: govuk-spacing(4);
+
+  @include govuk-media-query($from: desktop) {
+    max-width: 90%;
+    margin-bottom: 0;
+  }
+}
+
+.gem-c-cookie-banner__hide-button {
+  @include govuk-font($size: 19);
+  outline: 0;
+  border: 0;
+  background: none;
+  text-decoration: underline;
+  color: $govuk-link-colour;
+  padding: govuk-spacing(0);
+  margin-top: govuk-spacing(2);
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+    cursor: pointer;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    margin-top: govuk-spacing(0);
+    position: absolute;
+    right: govuk-spacing(1);
+  }
+}
+
+.gem-c-cookie-banner__buttons--flex {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+
+  .govuk-button,
+  .gem-c-cookie-banner__link {
+    flex-grow: 1;
+    flex-basis: 10rem;
+    margin-right: govuk-spacing(3);
+    margin-bottom: govuk-spacing(3);
+  }
+}
+
+// Override the styles from govuk_template
+// scss-lint:disable IdSelector
+// sass-lint:disable no-ids
+.gem-c-cookie-banner#global-cookie-message {
+  background-color: $govuk-cookie-banner-background;
+  padding: govuk-spacing(4) 0;
+  box-sizing: border-box;
+
+  .gem-c-cookie-banner__message,
+  .gem-c-cookie-banner__buttons,
+  .gem-c-cookie-banner__confirmation,
+  .gem-c-cookie-banner__confirmation-message {
+    @include govuk-font($size: 19);
+  }
+
+  .gem-c-cookie-banner__message {
+    margin-bottom: 0;
+  }
+
+  p {
+    @include govuk-font($size: 19);
+    margin: 0 0 govuk-spacing(2) 0;
+  }
+
+  .gem-c-cookie-banner__confirmation-message {
+    @include govuk-media-query($from: desktop) {
+      margin-bottom: 0;
+    }
+  }
+}
+// sass-lint:enable no-ids
+// scss-lint:enable IdSelector

--- a/app/views/includes/cookie-banner.html
+++ b/app/views/includes/cookie-banner.html
@@ -1,7 +1,39 @@
 {% if shouldShowCookieMessage %}
-  <div class="app-cookie-banner">
-    <p class="app-cookie-banner__message">
-      {{cookieText | safe }}
-    </p>
+  <div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="" style="display: block;">
+    <div class="gem-c-cookie-banner__wrapper govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class=" govuk-grid-column-two-thirds">
+          <div class="gem-c-cookie-banner__message">
+            <span class="govuk-heading-m">Tell us whether you accept cookies</span>
+            <p class="govuk-body">We use <a class="govuk-link" href="https://www.gov.uk/help/cookies">cookies to collect information</a> about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.</p>
+          </div>
+          <div class="gem-c-cookie-banner__buttons">
+            <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+
+
+
+    <button class="gem-c-button govuk-button gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept all cookies</button>
+
+
+            </div>
+            <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+
+
+
+    <a class="gem-c-button govuk-button gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="https://www.gov.uk/help/cookies">Set cookie preferences</a>
+
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
+      <p class="gem-c-cookie-banner__confirmation-message">
+        You’ve accepted all cookies. You can <a class="govuk-link" href="https://www.gov.uk/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.
+      </p>
+      <button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide</button>
+    </div>
   </div>
 {% endif %}

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -5,6 +5,9 @@
   <script src="{{scriptUrl}}"></script>
 {% endfor %}
 
+<script src="/public/javascripts/modules.js"></script>
+<script src="/public/javascripts/cookie.js"></script>
+<script src="/public/javascripts/cookie-banner.js"></script>
 <script src="/public/javascripts/application.js"></script>
 
 {% if useAutoStoreData %}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -291,22 +291,11 @@ exports.autoStoreData = function (req, res, next) {
 
 exports.handleCookies = function (app) {
   return function handleCookies (req, res, next) {
-    const COOKIE_NAME = 'seen_cookie_message'
+    const COOKIE_NAME = 'cookies_preferences_set'
     let cookie = req.cookies[COOKIE_NAME]
 
-    if (cookie === 'yes') {
-      app.locals.shouldShowCookieMessage = false
-      return next()
-    }
-
-    let maxAgeInDays = 28
-    res.cookie(COOKIE_NAME, 'yes', {
-      maxAge: maxAgeInDays * 24 * 60 * 60 * 1000,
-      httpOnly: true
-    })
-
-    app.locals.shouldShowCookieMessage = true
-
+    // String 'true' must match app/assets/javascripts/cookie-banner.js:55
+    app.locals.shouldShowCookieMessage = (cookie !== 'true')
     next()
   }
 }

--- a/server.js
+++ b/server.js
@@ -208,7 +208,8 @@ if (useAutoStoreData === 'true') {
 // Clear all data in session if you open /prototype-admin/clear-data
 app.post('/prototype-admin/clear-data', function (req, res) {
   req.session.data = {}
-  res.render('prototype-admin/clear-data-success')
+  res.clearCookie('cookies_preferences_set');
+  res.redirect('/prototype-admin/clear-data-success')
 })
 
 // Redirect root to /docs when in promo mode.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/355079/79243185-3097a100-7e6d-11ea-8b09-1046e5dd3851.png)
***

This pull request adds a cookie banner, which I have pilfered from the one used on GOV.UK Publishing.

I chose this one because it’s the one viewed by the most people, so any recommendations we make about it would have the biggest value.

It’s also likely to be the starting point for what services decide to copy, in the absence of a component in the Design System.

I personally want to test this because I have strong reckons about the negative impact on usability that cookie banners have, especially when services have seen a majority of users ignore the banner rather than dismiss it, therefore leading to it appearing on every. Single. Page. Load. I reckon there is a real trade off to be made between the usability of a service and the value of setting non-essential cookies. If this is the case then it would be good for us to have done the
research to help qualify this trade off.

I have chosen to link to the help pages on GOV.UK if the user clicks any of the links in the banner. This does take people out of the prototype and we could consider making these links non-functional. But I feel that the risk of people getting waylaid is true using a real service as well,
and we should see if this happens to people using our fake service.