### PR TITLE
Add new link styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^3.4.0",
+    "govuk-frontend": "github:alphagov/govuk-frontend#c62d16ee",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "github:alphagov/govuk-frontend#c62d16ee",
+    "govuk-frontend": "github:alphagov/govuk-frontend#6f638f97",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
<img width="703" alt="Screenshot 2020-04-16 at 14 50 18" src="https://user-images.githubusercontent.com/19834460/79464215-afb5e200-7ff1-11ea-9499-dcab9abd7612.png">

This PR pulls in a branch of GOV.UK Frontend with some new hover states we've been experimenting with on the Design System team. They use thicker underlines, similar to that of the focus state but inheriting the colours of the original link.