### PR TITLE
Add ‘Not completed’ tags to the task list

### DIFF
--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -59,12 +59,14 @@
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a class="govuk-link" href="/contact-preferences" aria-describedby="company-information-completed">
+                <a class="govuk-link" href="/contact-preferences" aria-describedby="contact-details-completed">
                   Contact details
                 </a>
               </span>
               {% if data['how-contacted'] and data['contact-by-' + data['how-contacted']] %}
-                <strong class="govuk-tag app-task-list__task-completed" id="company-information-completed">Completed</strong>
+                <strong class="govuk-tag app-task-list__task-completed" id="contact-details-completed">Completed</strong>
+              {% else %}
+                <strong class="govuk-tag govuk-tag--grey app-task-list__task-completed" id="contact-details-completed">Not completed</strong>
               {% endif %}
             </li>
           </ul>
@@ -76,10 +78,11 @@
           <ul class="app-task-list__items">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a class="govuk-link" href="/check-your-answers">
+                <a class="govuk-link" href="/check-your-answers" aria-describedby="submit-and-pay-completed">
                   Submit and pay
                 </a>
               </span>
+              <strong class="govuk-tag govuk-tag--grey app-task-list__task-completed" id="submit-and-pay-completed">Not completed</strong>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/355079/79470381-391ce280-7ff9-11ea-80fe-ce0547ee7e14.png)

We want to see if this makes it clearer to people what they need to do next when they land on the page.

Uses the [tag component](https://design-system.service.gov.uk/components/tag/) that’s recently been added to the Design System. I chose the grey one because it’s the default example given<sup>1</sup>, and it doesn’t have the same semantic associations as red, green or yellow.

***

1. ![image](https://user-images.githubusercontent.com/355079/79472300-91ed7a80-7ffb-11ea-9c26-5faf7b2483bd.png)
