### PR TITLE
Make header hover states white instead of blue

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -18,3 +18,17 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/cookie-banner";
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
+
+// Override hover state on links in the header
+// This is currently clashing with the new styles pulled in from frontend
+
+.govuk-header {
+
+  a:hover {
+    color: govuk-colour("white");
+    box-shadow: 0 -2px transparent, 0 4px govuk-colour("white");
+    text-decoration: none;
+    border-bottom: none;
+  }
+
+}


### PR DESCRIPTION
Bringing header hover states in line with what was intended:

<img width="1032" alt="Screenshot 2020-04-17 at 12 14 53" src="https://user-images.githubusercontent.com/19834460/79563646-1516db00-80a5-11ea-840e-55e77926dbc4.png">
