### PR TITLE
Add healthcare professionals conditional

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -32,3 +32,7 @@ $govuk-assets-path: '/govuk/assets/';
   }
 
 }
+
+.govuk-tag {
+  letter-spacing: inherit;
+}

--- a/app/assets/sass/components/_cookie-banner.scss
+++ b/app/assets/sass/components/_cookie-banner.scss
@@ -24,9 +24,10 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
   }
 }
 
+
 .gem-c-cookie-banner__button {
 
-  &.govuk-grid-column-one-half-from-desktop {
+  &.govuk-grid-column-one-quarter-from-desktop {
     padding: 0;
   }
 
@@ -40,14 +41,39 @@ $govuk-cookie-banner-background: govuk-colour("light-grey", "grey-4");
     }
 
   }
+    
+  .govuk-button--secondary {
+    background: #ffffff;
+    border: 2px solid #002D18;
+    box-shadow: 0 2px 0 #002d18;
+  }
+    
+  .govuk-link {
+    display: inline-block;
+    position: relative;
+    margin-top: 0;
+    margin-bottom: 22px;
+    padding: 8px 10px 7px;
+    text-align: center;
+    vertical-align: top; 
+    border: 2px solid transparent;
+    @include govuk-media-query($until: desktop) {
+      margin-bottom: govuk-spacing(4);
+    }
+  }
+    
 }
 
 // Only show accept button if users have js and can accept
-.gem-c-cookie-banner__button-accept {
+.gem-c-cookie-banner__button-accept, .gem-c-cookie-banner__button-reject {
   display: none;
 }
 
 .js-enabled .gem-c-cookie-banner__button-accept {
+  display: inline-block;
+}
+
+.js-enabled .gem-c-cookie-banner__button-reject {
   display: inline-block;
 }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -36,6 +36,60 @@ router.post('/type-of-badge', function (req, res) {
   res.redirect('/check-your-answers')
 })
 
+router.post('/list-healthcare-professionals', function (req, res) {
+  let errorSummary = []
+  let errors = {}
+
+  const selectedOption = req.body['are-details']
+  if (!selectedOption) {
+    const message = 'Select yes if you know the details of your healthcare professional'
+    errorSummary = [
+      {
+        text: message,
+        href: '#are-details-conditional'
+      }
+    ]
+    errors['are-details'] = {
+      text: message
+    }
+  }
+
+  const professionalName = req.body['healthcare-professional-name']
+  const town = req.body['address-town']
+  if (selectedOption === "yes" && (!professionalName || !town)) {
+    let textSuffix;
+    let href;
+
+    if (!professionalName) {
+      textSuffix = 'the name of your healthcare professional'
+      href = 'healthcare-professional-name'
+    }
+
+    else if (!town) {
+      textSuffix = 'the town your healthcare professional operates in'
+      href = 'address-town'
+    }
+
+    const message = 'Enter ' + textSuffix
+    errorSummary = [
+      {
+        text: message,
+        href: href
+      }
+    ]
+    errors['use-existing-image'] = true
+    errors[selectedOption] = {
+      text: message
+    }
+  }
+
+  if (errorSummary.length > 0) {
+    return res.render('list-healthcare-professionals.html', { errorSummary, errors })
+  }
+
+  res.redirect('/task-list')
+})
+
 router.post('/use-existing-image', function (req, res) {
   let errorSummary = []
   let errors = {}

--- a/app/routes.js
+++ b/app/routes.js
@@ -36,6 +36,82 @@ router.post('/type-of-badge', function (req, res) {
   res.redirect('/check-your-answers')
 })
 
+router.post('/use-existing-image', function (req, res) {
+  let errorSummary = []
+  let errors = {}
+
+  const selectedOption = req.body['use-existing-image']
+  if (!selectedOption) {
+    const message = 'Select yes if you would like to use your existing image'
+    errorSummary = [
+      {
+        text: message,
+        href: '#use-existing-image-conditional'
+      }
+    ]
+    errors['use-existing-image'] = {
+      text: message
+    }
+  }
+
+  const imageOption = req.body['existing-image-' + selectedOption]
+  if (selectedOption === "yes" && !imageOption) {
+    let textSuffix = 'existing badge number'
+    const message = 'Enter your ' + textSuffix
+    errorSummary = [
+      {
+        text: message,
+        href: '#existing-image-' + selectedOption
+      }
+    ]
+    errors['use-existing-image'] = true
+    errors[selectedOption] = {
+      text: message
+    }
+  }
+
+  if (errorSummary.length > 0) {
+    return res.render('use-existing-image.html', { errorSummary, errors })
+  }
+
+  else if (selectedOption === "yes") {
+    res.redirect('/task-list')
+  } else {
+    res.redirect('/upload-photo')
+  }
+})
+
+router.post('/upload-photo', function (req, res) {
+  let errorSummary = []
+  let notificationBanner = {}
+  let errors = {}
+
+  const uploadedPhoto = req.body['upload-photo']
+
+  if (!uploadedPhoto) {
+    const message = 'Please upload a digital photo (PNG, GIF or JPG file) that is no larger than 20MB'
+    errorSummary = [
+      {
+        text: message,
+        href: '#upload-photo'
+      }
+    ]
+    errors['upload-photo'] = {
+      text: "Please upload a photo"
+    }
+  } else {
+    notificationBanner = {
+      text: "Your photo has been successfully uploaded"
+    }
+  }
+
+  if (errorSummary.length > 0 ) {
+    return res.render('upload-photo.html', { errorSummary, errors})
+  }
+
+  return res.render('task-list', {notificationBanner})
+})
+
 router.post('/contact-preferences', function (req, res) {
   let errorSummary = []
   let errors = {}

--- a/app/routes.js
+++ b/app/routes.js
@@ -194,8 +194,9 @@ router.post('/contact-preferences', function (req, res) {
   let errors = {}
 
   const selectedOption = req.body['how-contacted']
-  if (!selectedOption) {
-    const message = 'Select your contact details'
+
+  if (selectedOption == "_unchecked") {
+    const message = 'Select at least one contact method'
     errorSummary = [
       {
         text: message,
@@ -205,30 +206,27 @@ router.post('/contact-preferences', function (req, res) {
     errors['how-contacted'] = {
       text: message
     }
-  }
+  } else {
+    selectedOption.forEach(function(option) {
+      const contactOption = req.body['contact-by-' + option]
+      if (!contactOption) {
+        let error = {}
+        error['href'] = '#contact-by-' + option
 
-  const contactOption = req.body['contact-by-' + selectedOption]
-  if (selectedOption && !contactOption) {
-    let textSuffix = ''
-    if (selectedOption === 'phone-number') {
-      textSuffix = 'phone number'
-    } else if (selectedOption === 'email-address') {
-      textSuffix = 'email address'
-    } else if (selectedOption === 'address') {
-      textSuffix = 'post address'
-    }
+        if (option === 'phone-number') {
+          error['text'] = 'Enter your phone number'
+          errors['phone-number'] = { text: "Enter your phone number" }
+        } else if (option === 'email-address') {
+          error['text'] = 'Enter your email address'
+          errors['email-address'] = { text: "Enter your email address" }
+        } else if (option === 'address') {
+          error['text'] = 'Enter your post address'
+          errors['address'] = { text: "Enter your post address" }
+        }
 
-    const message = 'Enter your ' + textSuffix
-    errorSummary = [
-      {
-        text: message,
-        href: '#contact-by-' + selectedOption
+        errorSummary.push(error)
       }
-    ]
-    errors['how-contacted'] = true
-    errors[selectedOption] = {
-      text: message
-    }
+    })
   }
 
   if (errorSummary.length > 0) {

--- a/app/views/contact-preferences.html
+++ b/app/views/contact-preferences.html
@@ -71,7 +71,7 @@
           }) }}
         {% endset -%}
 
-        {{ govukRadios({
+        {{ govukCheckboxes({
           idPrefix: "how-contacted-conditional",
           name: "how-contacted",
           fieldset: {
@@ -88,7 +88,7 @@
             {
               value: "phone-number",
               text: "Phone call",
-              checked: data['how-contacted'] === 'phone-number',
+              checked: data['how-contacted'] and data['how-contacted'].includes('phone-number'),
               conditional: {
                 html: phoneHtml
               }
@@ -96,7 +96,7 @@
             {
               value: "email-address",
               text: "Email",
-              checked: data['how-contacted'] === 'email-address',
+              checked: data['how-contacted'] and data['how-contacted'].includes('email-address'),
               conditional: {
                 html: emailHtml
               }
@@ -104,7 +104,7 @@
             {
               value: "address",
               text: "Post",
-              checked: data['how-contacted'] === 'address',
+              checked: data['how-contacted'] and data['how-contacted'].includes('address'),
               conditional: {
                 html: postHtml
               }

--- a/app/views/includes/cookie-banner.html
+++ b/app/views/includes/cookie-banner.html
@@ -5,26 +5,22 @@
         <div class=" govuk-grid-column-two-thirds">
           <div class="gem-c-cookie-banner__message">
             <span class="govuk-heading-m">Tell us whether you accept cookies</span>
-            <p class="govuk-body">We use <a class="govuk-link" href="https://www.gov.uk/help/cookies">cookies to collect information</a> about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.</p>
+            <p class="govuk-body">We use cookies to collect information about how you use GOV.UK. We use this information to make the website work as well as possible and improve government services.</p>
           </div>
-          <div class="gem-c-cookie-banner__buttons">
-            <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-
-
-
-    <button class="gem-c-button govuk-button gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept all cookies</button>
-
-
-            </div>
-            <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-
-
-
-    <a class="gem-c-button govuk-button gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="https://www.gov.uk/help/cookies">Set cookie preferences</a>
-
-
-            </div>
-          </div>
+        </div>
+        <div class="govuk-grid-column-full">
+            <div class="gem-c-cookie-banner__buttons">
+                <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-quarter-from-desktop">
+                    <button class="gem-c-button govuk-button gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept all cookies</button>
+                </div>
+                <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-reject govuk-grid-column-full govuk-grid-column-one-quarter-from-desktop">
+                    <button class="gem-c-button govuk-button govuk-button--secondary gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="false" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Reject all cookies</button>
+                </div>
+                <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-quarter-from-desktop">
+                    <a class="gem-c-button govuk-link gem-c-button--inline" 
+           data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="https://www.gov.uk/help/cookies">Set cookie preferences</a>
+                </div>
+              </div>
         </div>
       </div>
     </div>

--- a/app/views/list-healthcare-professionals.html
+++ b/app/views/list-healthcare-professionals.html
@@ -1,0 +1,134 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  {% if errorSummary.length > 0 %}Error: {% endif %}List healthcare professionals – {{ serviceName }} – GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/task-list"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if errorSummary.length > 0 %}
+          {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: errorSummary
+          }) }}
+      {% endif %}
+
+      <form class="form" method="post" novalidate>
+        {% set yesHtml %}
+          {% call govukFieldset({
+              legend: {
+                text: "What's the address of your healthcare professional?",
+                classes: "govuk-fieldset__legend--m",
+                isPageHeading: true
+              }
+            }) %}
+
+              {{ govukInput({
+                label: {
+                  html: 'Name of your healthcare professional'
+                },
+                id: "healthcare-professional-name",
+                name: "healthcare-professional-name",
+                value: data["healthcare-professional-name"]
+              }) }}
+
+              {{ govukInput({
+                label: {
+                  html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+                },
+                id: "address-line-1",
+                name: "address-line-1",
+                value: data["address-line-1"]
+              }) }}
+
+              {{ govukInput({
+                label: {
+                  html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+                },
+                id: "address-line-2",
+                name: "address-line-2",
+                value: data["address-line-2"]
+              }) }}
+
+              {{ govukInput({
+                label: {
+                  text: "Town or city"
+                },
+                classes: "govuk-!-width-two-thirds",
+                id: "address-town",
+                name: "address-town",
+                value: data["address-town"]
+              }) }}
+
+              {{ govukInput({
+                label: {
+                  text: "County"
+                },
+                classes: "govuk-!-width-two-thirds",
+                id: "address-county",
+                name: "address-county",
+                value: data["address-county"]
+              }) }}
+
+              {{ govukInput({
+                label: {
+                  text: "Postcode"
+                },
+                classes: "govuk-input--width-10",
+                id: "address-postcode",
+                name: "address-postcode",
+                value: data["address-postcard"]
+              }) }}
+
+            {% endcall %}
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: "are-details-conditional",
+          name: "are-details",
+          fieldset: {
+            legend: {
+              text: "Do you know the details of your healthcare professional?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "Give the address details of the healthcare professional involved in the treatment of your condition. For example, your surgeon, physiotherapist or GP."
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              checked: data['are-details'] === 'yes',
+              conditional: {
+                html: yesHtml
+              }
+            },
+            {
+              value: "no",
+              text: "No",
+              checked: data['are-details'] === 'no'
+            }
+          ],
+          errorMessage: errors['are-details']
+        }) }}
+
+        {{ govukButton({
+          text: "Submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -9,7 +9,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% if data['how-contacted'] and data['contact-by-' + data['how-contacted']]%}
+      {% if notificationBanner %}
+        {{ govukNotificationBanner({
+          type: notificationBanner['type'],
+          text: notificationBanner['text']
+        }) }}
+      {% endif %}
+
+      {% if data['use-existing-image'] and data['are-details'] and data['how-contacted'] and data['contact-by-' + data['how-contacted']]%}
         {{ govukNotificationBanner({
           "html": "
             <h3 class=govuk-notification-banner__heading>Information about your application</h3>

--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -81,6 +81,18 @@
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
+                <a class="govuk-link" href="/list-healthcare-professionals" aria-describedby="list-healthcare-professionals-completed">
+                  List healthcare professionals
+                </a>
+              </span>
+              {% if data['are-details'] %}
+                <strong class="govuk-tag app-task-list__task-completed" id="list-healthcare-professionals-completed">Completed</strong>
+              {% else %}
+                <strong class="govuk-tag govuk-tag--grey app-task-list__task-completed" id="list-healthcare-professionals-completed">Not completed</strong>
+              {% endif %}
+            </li>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
                 <a class="govuk-link" href="/contact-preferences" aria-describedby="contact-details-completed">
                   Contact details
                 </a>

--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -98,7 +98,7 @@
                   Contact details
                 </a>
               </span>
-              {% if data['how-contacted'] and data['contact-by-' + data['how-contacted']] %}
+              {% if data['how-contacted'] %}
                 <strong class="govuk-tag app-task-list__task-completed" id="contact-details-completed">Completed</strong>
               {% else %}
                 <strong class="govuk-tag govuk-tag--grey app-task-list__task-completed" id="contact-details-completed">Not completed</strong>

--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -67,11 +67,17 @@
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a class="govuk-link" href="/no-permission" aria-describedby="upload-a-photo-completed">
+                <a class="govuk-link" href="/use-existing-image" aria-describedby="upload-a-photo-completed">
                   Upload a photo
                 </a>
               </span>
-              <strong class="govuk-tag app-task-list__task-completed" id="upload-a-photo-completed">Completed</strong>
+              {% if data['use-existing-image'] === "yes" %}
+                <strong class="govuk-tag app-task-list__task-completed" id="upload-a-photo-completed">Completed</strong>
+              {% elif data['use-existing-image'] === "no" and data['upload-photo'] %}
+                <strong class="govuk-tag app-task-list__task-completed" id="upload-a-photo-completed">Completed</strong>
+              {% else %}
+                <strong class="govuk-tag govuk-tag--grey app-task-list__task-completed" id="upload-a-photo-completed">Not completed</strong>
+              {% endif %}
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">

--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -16,7 +16,7 @@
         }) }}
       {% endif %}
 
-      {% if data['use-existing-image'] and data['are-details'] and data['how-contacted'] and data['contact-by-' + data['how-contacted']]%}
+      {% if data['are-details'] and data['how-contacted'] and data['contact-by-' + data['how-contacted']]%}
         {{ govukNotificationBanner({
           "html": "
             <h3 class=govuk-notification-banner__heading>Information about your application</h3>
@@ -74,17 +74,11 @@
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a class="govuk-link" href="/use-existing-image" aria-describedby="upload-a-photo-completed">
+                <a class="govuk-link" href="/no-permission" aria-describedby="upload-a-photo-completed">
                   Upload a photo
                 </a>
               </span>
-              {% if data['use-existing-image'] === "yes" %}
-                <strong class="govuk-tag app-task-list__task-completed" id="upload-a-photo-completed">Completed</strong>
-              {% elif data['use-existing-image'] === "no" and data['upload-photo'] %}
-                <strong class="govuk-tag app-task-list__task-completed" id="upload-a-photo-completed">Completed</strong>
-              {% else %}
-                <strong class="govuk-tag govuk-tag--grey app-task-list__task-completed" id="upload-a-photo-completed">Not completed</strong>
-              {% endif %}
+              <strong class="govuk-tag app-task-list__task-completed" id="upload-a-photo-completed">Completed</strong>
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">

--- a/app/views/upload-photo.html
+++ b/app/views/upload-photo.html
@@ -23,6 +23,13 @@
           }) }}
       {% endif %}
 
+      {% if randomError %}
+        {{ govukNotificationBanner({
+          "type": "error",
+          "html": "<h3 class=govuk-notification-banner__heading>Sorry, there has been a problem uploading your photo</h3><p class=govuk-body>Please try again.</p>"
+        }) }}
+      {% endif %}
+
       <h1 class="govuk-heading-l">
         Add a photo of yourself
       </h1>

--- a/app/views/upload-photo.html
+++ b/app/views/upload-photo.html
@@ -1,0 +1,68 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  {% if errorSummary.length > 0 %}Error: {% endif %}Upload a photo – {{ serviceName }} – GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/task-list"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if errorSummary.length > 0 %}
+          {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: errorSummary
+          }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">
+        Add a photo of yourself
+      </h1>
+
+      <p class="govuk-body">You need to add a recent digital photo to be printed on the back of your badge.</p>
+
+      <p class="govuk-body">
+        Make sure it
+        <ul class="govuk-list govuk-list--bullet">
+          <li>has a plain, light background</li>
+          <li>includes your shoulders</li>
+          <li>shows your face clearly</li>
+        </ul>
+
+      </p>
+
+      <form class="form" method="post" novalidate>
+        <div class="govuk-form-group">
+          {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+
+          {{ govukFileUpload({
+            id: "upload-photo",
+            name: "upload-photo",
+            value: data['upload-photo'],
+            label: {
+              text: "Upload a photo of yourself"
+            },
+            hint: {
+              text: "You can use a digital camera, smartphone, or tablet to take a photo, or use a scanner. If you already have a digital photo, it will need to be a PNG, GIF or JPG file, and no larger than 20MB."
+            },
+            errorMessage: errors['upload-photo']
+          }) }}
+        </div>
+        {% from "govuk/components/button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          text: "Submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/use-existing-image.html
+++ b/app/views/use-existing-image.html
@@ -1,0 +1,84 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  {% if errorSummary.length > 0 %}Error: {% endif %}Use an existing image – {{ serviceName }} – GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/task-list"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if errorSummary.length > 0 %}
+          {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: errorSummary
+          }) }}
+      {% endif %}
+
+      <form class="form" method="post" novalidate>
+        {% set yesHtml %}
+          {{ govukInput({
+            id: "existing-image-yes",
+            name: "existing-image-yes",
+            classes: "govuk-!-width-two-thirds",
+            label: {
+              text: "Existing badge number"
+            },
+            hint: {
+              text: "For example, 242G48"
+            },
+            attributes: {
+              spellcheck: "false"
+            },
+            value: data['existing-image-yes'],
+            errorMessage: errors['existing-image-yes']
+          }) }}
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: "use-existing-image-conditional",
+          name: "use-existing-image",
+          fieldset: {
+            legend: {
+              text: "Do you want to use the image from your previous Blue Badge",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: ""
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              checked: data['use-existing-image'] === 'yes',
+              conditional: {
+                html: yesHtml
+              }
+            },
+            {
+              value: "no",
+              text: "No",
+              checked: data['use-existing-image'] === 'no'
+            }
+          ],
+          errorMessage: errors['use-existing-image']
+        }) }}
+
+        {{ govukButton({
+          text: "Submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
__Follows on from https://github.com/alphagov/gaap-assistive-tech-research-prototype/pull/42 - will need to be rebased once that's merged into main__

Adds two conditional reveal tasks to the blue badge journey:
1. Adds a radio input conditional reveal task to the upload photo journey (this task is hidden later as we don't want to force users to have to upload a photo during the user research session)
2. Adds a radio input conditional reveal task to a new 'list healthcare professionals' section of the journey
3. Converts the contact preferences question to use checkbox conditional reveal

This PR also adds notification banners throughout the journey, specifically:
1. An error notification banner during the upload photo journey, so the first upload of a photo always results in a server/service error
2. A success banner on the task list page when someone submits healthcare professional details