### PR TITLE
Update govuk-frontend pre-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "github:alphagov/govuk-frontend#7448786f",
+    "govuk-frontend": "github:alphagov/govuk-frontend#bb33f524",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
The pre-release has been rebased against govuk-frontend master to get the fixes from the latest patch release for notification banner.