### PR TITLE
BAU: Fix 3DS pages

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -319,8 +319,7 @@ router.get('/backstage/document-sent', function(req, res) {
 //GOV PAY Integration
 
 axios.defaults.baseURL = process.env.PAY_API_BASE_URL
-axios.defaults.headers.common['Authorization'] =
-  `Bearer ${process.env.PAY_API_KEY}`
+axios.defaults.headers.common['Authorization'] = `Bearer ${process.env.PAY_API_KEY}`
 axios.defaults.headers.post['Content-Type'] = 'application/json'
 
 router.get('/pay/create-payment', function (req, res) {
@@ -344,7 +343,7 @@ router.get('/pay/create-payment', function (req, res) {
       const UPDATED_NEXT_URL = response.data._links.next_url.href.replace(
         process.env.PAY_TEST_FRONTEND_BASE_URL,
         process.env.PAY_FARGATE_FRONTEND_BASE_URL
-      );
+      )
 
       console.log('PAY - return url: ', UPDATED_NEXT_URL)
 

--- a/app/views/3ds-step-1.html
+++ b/app/views/3ds-step-1.html
@@ -20,7 +20,7 @@ Submit and pay – {{ serviceName }} – GOV.UK
     <img src="/public/images/loading-spin.gif" style="display:inline;" width="100" alt="loading page indicator">
     <div class="govuk-!-padding-bottom-8"></div>
 
-    <p class="govuk-body govuk-!-margin-bottom-6">If you are not automatically redirected n 10 seconds, <a href="/3ds-step-2" class="govuk-link">click here to continue with your payment</a></p>
+    <p class="govuk-body govuk-!-margin-bottom-6">If you are not automatically redirected in 10 seconds, <a href="/3ds-step-2" class="govuk-link">click here to continue with your payment</a></p>
 
     <!-- i used the edited back link code for the above link changing the # to the link needed and word 'back' from govuk-link in order to remove the back arrow -->
   </div>

--- a/app/views/3ds-step-2.html
+++ b/app/views/3ds-step-2.html
@@ -39,11 +39,15 @@ Submit and pay – {{ serviceName }} – GOV.UK
 			<div class="govuk-error-summary__body">
 				<h3 class="govuk-heading-s">Blue badge - Governme via</h3>
 				<h3 class="govuk-error-summary__title" id="error-summary-title">
-					£10.00
+					{% if data['delivery-method'] === 'fast-track' %}
+					{{ "£18.50" }}
+					{% else %}
+					{{ "£10.00" }}
+					{% endif %}
 				</h3>
 				<p class="govuk-body govuk-!-margin-bottom-6">CAR12345_Worldpay</p>
 				<!-- add icon image for card here-->
-				<p class="govuk-body govuk-!-margin-bottom-6">**** **** **** 4321</p>
+				<p class="govuk-body govuk-!-margin-bottom-6">**** **** **** 1111</p>
 				<h3 class="govuk-heading-s">
 					Complete your ID verification to approve this payment
 				</h3>


### PR DESCRIPTION
This change

- fixes the spelling of in on the first 3DS page.
- fixes the card number on the second 3DS page.
- updates the second 3DS page to use correct charge amount depending on the delivery method.