### PR TITLE
Update pre-release

### DIFF
--- a/app/views/can-i-get-a-blue-badge.html
+++ b/app/views/can-i-get-a-blue-badge.html
@@ -17,11 +17,11 @@
       </p>
 
       <p>
-        In <a href="#">England, Scotland and Wales you can apply on GOV.UK</a> for a Blue Badge.
+        In <a class="govuk-link" href="#">England, Scotland and Wales you can apply on GOV.UK</a> for a Blue Badge.
       </p>
 
       <p class="govuk-!-margin-bottom-8">
-        There’s a different way to <a href="#">apply if you’re in Northern Ireland</a>.
+        There’s a different way to <a class="govuk-link" href="#">apply if you’re in Northern Ireland</a>.
       </p>
 
       {% from "govuk/components/accordion/macro.njk" import govukAccordion %}
@@ -35,7 +35,7 @@
               text: "People who automatically get a Blue Badge"
             },
             content: {
-              html: '<p> You automatically qualify for a Blue Badge if you are over 2 years old and at least one of the following applies: </p> <ul class="govuk-list govuk-list--bullet"> <li>you receive the higher rate of the mobility component of the <a href="#">Disability Living Allowance (DLA)</a></li> <li>you receive a <a href="#">Personal Independence Payment (PIP)</a> because you can’t walk more than 50 metres (a score of 8 points or more under the ‘moving around’ activity of the mobility component)</li> <li>you are registered blind (severely sight impaired)</li> <li>you receive a War Pensioner’s Mobility Supplement</li> <li>you have received a lump sum benefit within tariff levels 1-8 of the Armed Forces and Reserve Forces (Compensation) Scheme and have been certified as having a permanent and substantial disability which causes inability to walk or very considerable difficulty in walking</li> <li>you receive the mobility component of PIP and have obtained 10 points specifically for descriptor E under the ‘planning and following journeys’ activity, on the grounds that you are unable to undertake any journey because it would cause you overwhelming psychological distress</li> </ul> <div class="govuk-inset-text"> If you have any score other than 10 points under descriptor E, in the ‘planning and following journeys’ activity of PIP you may still be eligible for a Blue Badge, but you do not automatically qualify. This includes if you have a higher score of 12. You will have to provide evidence to demonstrate your eligibility which will be assessed as part of your application. </div> <h3 class="govuk-heading-s"> Scotland </h3> <p>In Scotland you are also automatically eligible if at least one of the following applies:</p> <ul class="govuk-list govuk-list--bullet"> <li>you scored 12 points in the ‘planning and following journeys’ part of your mobility assessment for PIP</li> <li>you previously received the higher rate of the mobility component for DLA indefinitely</li> <li>you have had a mandatory reconsideration for PIP accepted by the Department for Work and Pensions (DWP) - you are eligible for a 1 year badge</li> </ul> <h3 class="govuk-heading-s"> Wales </h3> <p>In Wales you are also automatically eligible if at least one of the following applies:</p> <ul class="govuk-list govuk-list--bullet"> <li>you scored 12 points in the ‘planning and following journeys’ part of your mobility assessment for PIP</li> <li>you receive tariff level 6 of the Armed Forces Compensation Scheme for a permanent mental disorder</li> </ul>'
+              html: '<p> You automatically qualify for a Blue Badge if you are over 2 years old and at least one of the following applies: </p> <ul class="govuk-list govuk-list--bullet"> <li>you receive the higher rate of the mobility component of the <a class="govuk-link" href="#">Disability Living Allowance (DLA)</a></li> <li>you receive a <a class="govuk-link" href="#">Personal Independence Payment (PIP)</a> because you can’t walk more than 50 metres (a score of 8 points or more under the ‘moving around’ activity of the mobility component)</li> <li>you are registered blind (severely sight impaired)</li> <li>you receive a War Pensioner’s Mobility Supplement</li> <li>you have received a lump sum benefit within tariff levels 1-8 of the Armed Forces and Reserve Forces (Compensation) Scheme and have been certified as having a permanent and substantial disability which causes inability to walk or very considerable difficulty in walking</li> <li>you receive the mobility component of PIP and have obtained 10 points specifically for descriptor E under the ‘planning and following journeys’ activity, on the grounds that you are unable to undertake any journey because it would cause you overwhelming psychological distress</li> </ul> <div class="govuk-inset-text"> If you have any score other than 10 points under descriptor E, in the ‘planning and following journeys’ activity of PIP you may still be eligible for a Blue Badge, but you do not automatically qualify. This includes if you have a higher score of 12. You will have to provide evidence to demonstrate your eligibility which will be assessed as part of your application. </div> <h3 class="govuk-heading-s"> Scotland </h3> <p>In Scotland you are also automatically eligible if at least one of the following applies:</p> <ul class="govuk-list govuk-list--bullet"> <li>you scored 12 points in the ‘planning and following journeys’ part of your mobility assessment for PIP</li> <li>you previously received the higher rate of the mobility component for DLA indefinitely</li> <li>you have had a mandatory reconsideration for PIP accepted by the Department for Work and Pensions (DWP) - you are eligible for a 1 year badge</li> </ul> <h3 class="govuk-heading-s"> Wales </h3> <p>In Wales you are also automatically eligible if at least one of the following applies:</p> <ul class="govuk-list govuk-list--bullet"> <li>you scored 12 points in the ‘planning and following journeys’ part of your mobility assessment for PIP</li> <li>you receive tariff level 6 of the Armed Forces Compensation Scheme for a permanent mental disorder</li> </ul>'
             }
           },
           {
@@ -78,7 +78,7 @@
             text: "How you can provide documents"
           },
           content: {
-            html: '<p>When you are applying online, you’ll be able to upload a photo or scan of:</p><ul class="govuk-list govuk-list--bullet"> <li>proof of benefit</li> <li>proof of address</li> <li>proof of identity</li> <li>supporting documents</li></ul><p>You can also upload a recent digital photo. Just make sure the photos or scans are good quality and include all of the relevant information.</p><p>If you are applying on a mobile or tablet device, you can take a photo of the required documents and upload within the application itself.</p><p>You can choose not to upload the documents when you’re applying. If you do this you’ll need to supply copies of the documents to the local council. Find out how to <a href="https://www.gov.uk/find-local-council" class="govuk-link">contact your local council</a>.</p><p>Instead, if you receive one of these benefits, you can still apply and your application will be assessed by your local council.</p>'
+            html: '<p>When you are applying online, you’ll be able to upload a photo or scan of:</p><ul class="govuk-list govuk-list--bullet"> <li>proof of benefit</li> <li>proof of address</li> <li>proof of identity</li> <li>supporting documents</li></ul><p>You can also upload a recent digital photo. Just make sure the photos or scans are good quality and include all of the relevant information.</p><p>If you are applying on a mobile or tablet device, you can take a photo of the required documents and upload within the application itself.</p><p>You can choose not to upload the documents when you’re applying. If you do this you’ll need to supply copies of the documents to the local council. Find out how to <a class="govuk-link" href="https://www.gov.uk/find-local-council" class="govuk-link">contact your local council</a>.</p><p>Instead, if you receive one of these benefits, you can still apply and your application will be assessed by your local council.</p>'
           }
         },
           {
@@ -101,10 +101,10 @@
       </p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li><a href="https://www.gov.uk/government/publications/the-blue-badge-scheme-rights-and-responsibilities-in-england">Blue Badge rules for England</a></li>
-        <li><a href="https://www.nidirect.gov.uk/articles/rights-and-responsibilities-blue-badge-holders">Blue Badge rules for Northern Ireland</a></li>
-        <li><a href="https://www.mygov.scot/blue-badge-scheme/">Blue Badge rules for Scotland</a></li>
-        <li><a href="https://gov.wales/blue-badges-your-rights-and-responsibilities">Blue Badge rules for Wales</a></li>
+        <li><a class="govuk-link" href="https://www.gov.uk/government/publications/the-blue-badge-scheme-rights-and-responsibilities-in-england">Blue Badge rules for England</a></li>
+        <li><a class="govuk-link" href="https://www.nidirect.gov.uk/articles/rights-and-responsibilities-blue-badge-holders">Blue Badge rules for Northern Ireland</a></li>
+        <li><a class="govuk-link" href="https://www.mygov.scot/blue-badge-scheme/">Blue Badge rules for Scotland</a></li>
+        <li><a class="govuk-link" href="https://gov.wales/blue-badges-your-rights-and-responsibilities">Blue Badge rules for Wales</a></li>
       </ul>
 
     </div>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "github:alphagov/govuk-frontend#bb33f524",
+    "govuk-frontend": "github:alphagov/govuk-frontend#8f193107",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
Fixes https://github.com/alphagov/gaap-assistive-tech-research-prototype/issues/60

The prototype has govuk-global-styles switched on which sets the govuk-link style on all <a> tags. The new pre-release removes the automatic govuk-link styling on all <a> tags. Prototype checked and all links still have the new hover state. 