### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": "package-lock.json",
-    "lines": null
-  },
-  "generated_at": "2020-11-30T14:45:48Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,47 +53,91 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package-lock.json"
+      ]
+    }
+  ],
   "results": {
-    "docs/documentation/publishing-on-heroku.md": [
+    ".pre-commit-config.yaml": [
       {
-        "hashed_secret": "88d5f0d556ec8a3f863c0d8ea710db73bc0731f3",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
         "is_verified": false,
-        "line_number": 55,
-        "type": "Secret Keyword"
+        "line_number": 3
       }
     ],
-    "docs/documentation/using-notify.md": [
+    ".travis.yml": [
       {
-        "hashed_secret": "2db6d21d365f544f7ca3bcfb443ac96898a7a069",
-        "is_secret": false,
+        "type": "Base64 High Entropy String",
+        "filename": ".travis.yml",
+        "hashed_secret": "40245844e8a93b904b846412d08c760e06362de7",
         "is_verified": false,
-        "line_number": 37,
-        "type": "Secret Keyword"
+        "line_number": 28
       }
     ],
     "lib/middleware/authentication/authentication.test.js": [
       {
+        "type": "Secret Keyword",
+        "filename": "lib/middleware/authentication/authentication.test.js",
         "hashed_secret": "354b3a4b7715d3694c88a4fa7db49e41de86568e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 60,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ],
     "manifest.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "manifest.yml",
         "hashed_secret": "e380f79b36c3093d5c5bb35139815f69054f0636",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-17T11:29:39Z"
 }

--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ brew install cloudfoundry/tap/cf-cli
 cf login -a api.cloud.service.gov.uk -o gds-design
 cf push
 ```
+
+## Preventing accidently committing secrets / passwords to the Git repo
+
+This repo uses the recommended tools from Cyber to prevent accidently committing secrets / passwords.
+
+It is recommended to install these tools when working on this repository.
+More information is available here:
+- https://github.com/alphagov/gds-pre-commit
+
+Once setup, you need to run the following command to set up the git commit hooks:
+```shell
+pre-commit install
+```


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`